### PR TITLE
develop to main

### DIFF
--- a/app/api/v2/in_game_router.py
+++ b/app/api/v2/in_game_router.py
@@ -17,9 +17,9 @@ async def generate_questions(request: Request, question_data: game_schema.Questi
     try:
         questions = game_service.generate_npc_questions(
             question_data.gameNo, 
-            question_data.npc_name, 
-            question_data.keyword, 
-            question_data.keyword_type
+            question_data.npcName, 
+            question_data.keyWord, 
+            question_data.keyWordType
         )
         return {"questions": questions}
     except ValueError as e:
@@ -35,10 +35,10 @@ async def talk_to_npc(request: Request, answer_data: game_schema.AnswerRequest):
     try:
         response = game_service.talk_to_npc(
             answer_data.gameNo, 
-            answer_data.npc_name, 
-            answer_data.question_index, 
-            answer_data.keyword, 
-            answer_data.keyword_type
+            answer_data.npcName, 
+            answer_data.questionIndex, 
+            answer_data.keyWord, 
+            answer_data.keyWordType
         )
         return {"response": response}
     except ValueError as e:

--- a/app/api/v2/new_game_router.py
+++ b/app/api/v2/new_game_router.py
@@ -18,7 +18,7 @@ async def start_game(request: Request, game_data: game_schema.GameStartRequest):
         raise HTTPException(status_code=400, detail="Invalid language. Choose 'en' or 'ko'.")
     try:
         game_state = game_service.initialize_new_game(game_data)
-        return {"message": "New game started"}
+        return {"answer": game_state['first_blood']}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/app/api/v2/new_game_router.py
+++ b/app/api/v2/new_game_router.py
@@ -17,7 +17,7 @@ async def start_game(request: Request, game_data: game_schema.GameStartRequest):
     if game_data.language not in ["en", "ko"]:
         raise HTTPException(status_code=400, detail="Invalid language. Choose 'en' or 'ko'.")
     try:
-        game_service.initialize_new_game(game_data.gameNo, game_data.language, game_data.npc_count)
+        game_service.initialize_new_game(game_data.gameNo, game_data.language)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"message": "New game started"}

--- a/app/api/v2/new_game_router.py
+++ b/app/api/v2/new_game_router.py
@@ -17,10 +17,12 @@ async def start_game(request: Request, game_data: game_schema.GameStartRequest):
     if game_data.language not in ["en", "ko"]:
         raise HTTPException(status_code=400, detail="Invalid language. Choose 'en' or 'ko'.")
     try:
-        game_service.initialize_new_game(game_data.gameNo, game_data.language)
+        game_state = game_service.initialize_new_game(game_data)
+        return {"message": "New game started"}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    return {"message": "New game started"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
 
 # 시나리오를 생성하는 라우터
 @router.post("/generate-scenario", 
@@ -77,5 +79,18 @@ def save_progress(request: Request, game_data: game_schema.GameRequest):
         game_state = game_service.get_game_status(game_data.gameNo)
         result = game_service.save_game_progress(game_data.gameNo, game_state)
         return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+# 알리바이와 목격자 정보를 생성하는 라우터
+@router.post("/generate-alibis-and-witness", 
+            description="해당 게임의 알리바이와 목격자 정보를 생성하는 API입니다.")
+async def generate_alibis_and_witness(request: Request, game_data: game_schema.GameRequest):
+    game_service: GameService = request.app.state.game_service
+    try:
+        alibis_and_witness = game_service.generate_alibis_and_witness(game_data.gameNo)
+        return alibis_and_witness
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/app/schemas/game_schema.py
+++ b/app/schemas/game_schema.py
@@ -31,7 +31,7 @@ class GameState(BaseModel):
 class GameStartRequest(BaseModel):
     gameNo: int
     language: str = "ko"
-    npc_count: int = 6
+    # npc_count: int = 6
 
 class GameRequest(BaseModel):
     gameNo: int

--- a/app/schemas/game_schema.py
+++ b/app/schemas/game_schema.py
@@ -28,23 +28,64 @@ class GameState(BaseModel):
     current_questions: List[str] = []
     user_language: str = "en"
 
+class NPCInfo(BaseModel):
+    npcName: str
+    npcJob: str
+
 class GameStartRequest(BaseModel):
-    gameNo: int
+    gameNo: int = 0
     language: str = "ko"
-    # npc_count: int = 6
+    characters: List[NPCInfo] = [
+    {
+        "npcName": "김쿵야",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "박동식",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "짠짠영",
+        "npcJob": "Murderer"
+    },
+    {
+        "npcName": "태근티비",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "박윤주",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "테오",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "소피아",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "마르코",
+        "npcJob": "Resident"
+    },
+    {
+        "npcName": "알렉스",
+        "npcJob": "Resident"
+    }
+]
 
 class GameRequest(BaseModel):
     gameNo: int
 
 class QuestionRequest(BaseModel):
     gameNo: int
-    npc_name: str
-    keyword: str
-    keyword_type: str = "weapon"
+    npcName: str
+    keyWord: str
+    keyWordType: str = "weapon"
 
 class AnswerRequest(BaseModel):
     gameNo: int
-    npc_name: str
-    question_index: int
-    keyword: str
-    keyword_type: str = "weapon"
+    npcName: str
+    questionIndex: int
+    keyWord: str
+    keyWordType: str = "weapon"

--- a/app/services/game_management.py
+++ b/app/services/game_management.py
@@ -25,47 +25,63 @@ class GameManagement:
         self.game_state = None
 
     # 새로운 게임을 초기화하는 메서드
-    def initialize_game(self, language, npc_count):
-        if npc_count > len(self.npcs):
-            raise ValueError("NPC count exceeds available NPCs")
+    def initialize_game(self, language, characters, murderer):
+        # NPC 이름 사전 생성 (한글 이름 -> id 매핑)
+        npc_name_dict = {name["name"]["ko"]: name["id"] for name in self.names}
+        
+        # 유효성 검사
+        invalid_chars = [char for char in characters if char not in npc_name_dict]
+        if invalid_chars:
+            raise ValueError(f"Invalid characters: {', '.join(invalid_chars)}")
+        
+        if murderer not in characters:
+            raise ValueError(f"Murderer {murderer} is not in the character list")
 
-        selected_npcs = random.sample(self.npcs, npc_count)
-        murderer = random.choice(selected_npcs)
-        remaining_npcs = [npc for npc in self.npcs if npc not in selected_npcs]
-        murdered_npc = random.choice(remaining_npcs)
+        # 선택된 NPC 목록 생성
+        selected_npcs = [npc for npc in self.npcs if npc["name"] in [npc_name_dict[char] for char in characters]]
+        murderer_npc = next((npc for npc in selected_npcs if npc["name"] == npc_name_dict[murderer]), None)
+        
+        if murderer_npc is None:
+            raise ValueError(f"Murderer {murderer} not found in NPC list")
+
+        # 첫 번째 희생자 선택 (선택된 NPC 중 살인자가 아닌 사람)
+        potential_victims = [npc for npc in selected_npcs if npc != murderer_npc]
+        if not potential_victims:
+            raise ValueError("Not enough NPCs for victim selection")
+        
+        murdered_npc = random.choice(potential_victims)
 
         # 무기를 랜덤으로 할당
         weapons = load_weapons_data()["weapons"]
         for npc in selected_npcs:
-            npc["preferredWeapons"] = random.sample([weapon["id"] for weapon in weapons], 3)
+            npc["preferredWeapons"] = random.sample([weapon["id"] for weapon in weapons], min(3, len(weapons)))
 
         # 장소를 랜덤으로 할당
         places = load_places_data()["places"]
         for npc in selected_npcs:
-            npc["preferredLocations"] = random.sample([place["id"] for place in places], 3)
+            npc["preferredLocations"] = random.sample([place["id"] for place in places], min(3, len(places)))
 
-        murder_weapon = random.choice(murderer["preferredWeapons"])
-        murder_location = random.choice(murderer["preferredLocations"])
+        murder_weapon = random.choice(murderer_npc["preferredWeapons"])
+        murder_location = random.choice(murderer_npc["preferredLocations"])
 
         self.game_state = {
             "language": language,
-            "suspects": selected_npcs.copy(),
-            "murderer": murderer,
+            "suspects": [npc for npc in selected_npcs if npc != murdered_npc],
+            "murderer": murderer_npc,
             "murdered_npc": murdered_npc,
             "murder_weapon": murder_weapon,
             "murder_location": murder_location,
             "conversations_left": 5,
-            "npcs": selected_npcs,
+            "npcs": [npc for npc in selected_npcs if npc != murdered_npc],
             "places": self.places,
             "weapons": self.weapons,
             "conversations": [],
             "current_day": 1,
-            "alive": {npc["name"]: True for npc in selected_npcs},
+            "alive": {npc["name"]: (npc != murdered_npc) for npc in selected_npcs},
             "murdered_npcs": [{"name": murdered_npc["name"], "day": 1}]
         }
-        for npc in self.game_state["npcs"]:
-            if npc["name"] == murdered_npc["name"]:
-                npc["alive"] = False
+
+        return self.game_state
 
     # 게임 상태를 반환하는 메서드
     def get_game_status(self):
@@ -79,7 +95,8 @@ class GameManagement:
                 "feature": get_feature_detail(npc["feature"], self.features, lang),
                 "preferredWeapons": [get_weapon_name(weapon, self.weapons, lang) for weapon in npc["preferredWeapons"]],
                 "preferredLocations": [get_location_name(location, self.places, lang) for location in npc["preferredLocations"]],
-                "alive": self.game_state['alive'][npc['name']]
+                "alive": self.game_state['alive'][npc['name']],
+                "alibi": self.game_state.get('alibis', {}).get(get_name(npc["name"], lang, self.names), "")
             }
             for npc in self.game_state["npcs"]
         ]
@@ -97,6 +114,11 @@ class GameManagement:
             "personality": get_personality_detail(self.game_state["murdered_npc"]["personality"], self.personalities, lang),
             "feature": get_feature_detail(self.game_state["murdered_npc"]["feature"], self.features, lang)
         }
+        
+        witness_info = self.game_state.get('witness', {})
+        witness_name = witness_info.get('name', '')
+        eyewitness_information = witness_info.get('information', '')
+        
         return {
             "suspects": npc_info,
             "murderer": murderer_info,
@@ -105,5 +127,7 @@ class GameManagement:
             "murder_location": get_location_name(self.game_state["murder_location"], self.places, lang),
             "current_day": self.game_state["current_day"],
             "alive": self.game_state["alive"],
-            "murdered_npcs": self.game_state["murdered_npcs"]
+            "murdered_npcs": self.game_state["murdered_npcs"],
+            "witness": witness_name,
+            "eyewitnessInformation": eyewitness_information
         }

--- a/app/services/game_service.py
+++ b/app/services/game_service.py
@@ -1,4 +1,6 @@
 import random
+from typing import List
+from app.schemas import game_schema
 from app.services.game_management import GameManagement
 from app.services.question_generation import QuestionGeneration
 from app.services.hint_investigation import HintInvestigation
@@ -14,26 +16,16 @@ class GameService:
         self.game_states: dict[int, dict] = {}
 
     # 새로운 게임을 시작하고 초기화하는 메서드
-    def initialize_new_game(self, gameNo, language):
+    def initialize_new_game(self, game_data: game_schema.GameStartRequest):
         game_management = GameManagement()
-        game_management.initialize_game(language, 9)
-        game_state = game_management.game_state
-        game_state['current_day'] = 1
-        game_state['alive'] = {npc["name"]: True for npc in game_state["npcs"]}
-        game_state['murdered_npcs'] = []
-
-        # 첫 번째 희생자 설정
-        first_victim = game_state['murdered_npc']
-        for npc in game_state["npcs"]:
-            if npc["name"] == first_victim["name"]:
-                npc["alive"] = False
-                break
-        game_state['alive'][first_victim['name']] = False
-        game_state['murdered_npcs'].append({"name": first_victim['name'], "order": 1})
-
-        self.game_managements[gameNo] = game_management
-        self.game_states[gameNo] = game_state
-        self.question_generations[gameNo] = QuestionGeneration(
+        characters = [char.npcName for char in game_data.characters]
+        murderer = next(char.npcName for char in game_data.characters if char.npcJob == "Murderer")
+        
+        game_state = game_management.initialize_game(game_data.language, characters, murderer)
+        
+        self.game_managements[game_data.gameNo] = game_management
+        self.game_states[game_data.gameNo] = game_state
+        self.question_generations[game_data.gameNo] = QuestionGeneration(
             game_state,
             game_management.personalities,
             game_management.features,
@@ -41,12 +33,12 @@ class GameService:
             game_management.places,
             game_management.names
         )
-        self.hint_investigations[gameNo] = HintInvestigation(
+        self.hint_investigations[game_data.gameNo] = HintInvestigation(
             game_state,
             game_management.places,
             game_management.weapons
         )
-        self.scenario_generations[gameNo] = ScenarioGeneration(
+        self.scenario_generations[game_data.gameNo] = ScenarioGeneration(
             game_state,
             game_management.personalities,
             game_management.features,
@@ -54,6 +46,8 @@ class GameService:
             game_management.places,
             game_management.names
         )
+
+        return game_state
 
     # 게임 상태를 반환하는 메서드
     def get_game_status(self, gameNo):
@@ -81,16 +75,16 @@ class GameService:
         return self.scenario_generations[gameNo].generate_chief_letter()
 
     # 질문을 생성하는 메서드
-    def generate_npc_questions(self, gameNo, npc_name, keyword, keyword_type):
+    def generate_npc_questions(self, gameNo, npcName, keyWord, keyWordType):
         if gameNo not in self.question_generations:
             raise ValueError(f"Game ID {gameNo} not found in question generations.")
-        return self.question_generations[gameNo].generate_questions(npc_name, keyword, keyword_type)
+        return self.question_generations[gameNo].generate_questions(npcName, keyWord, keyWordType)
 
     # NPC와 대화를 진행하는 메서드
-    def talk_to_npc(self, gameNo, npc_name, question_index, keyword, keyword_type):
+    def talk_to_npc(self, gameNo, npcName, questionIndex, keyWord, keyWordType):
         if gameNo not in self.question_generations:
             raise ValueError(f"Game ID {gameNo} not found in question generations.")
-        return self.question_generations[gameNo].talk_to_npc(npc_name, question_index, keyword, keyword_type)
+        return self.question_generations[gameNo].talk_to_npc(npcName, questionIndex, keyWord, keyWordType)
 
     # 범행 장소를 조사하는 메서드
     def investigate_location(self, gameNo, location_name):
@@ -112,41 +106,28 @@ class GameService:
 
     # 다음 날로 넘어가는 메서드
     def proceed_to_next_day(self, gameNo):
-        game_state = self.game_states.get(gameNo)
-        if not game_state:
+        if gameNo not in self.game_states:
             raise ValueError("Game ID not found")
 
-        remaining_npcs = [npc for npc in game_state['npcs'] if game_state['alive'][npc['name']]]
-        if len(remaining_npcs) <= 2:
-            raise ValueError("Not enough NPCs to continue the game")
+        scenario_generation = self.scenario_generations[gameNo]
+        murder_summary = scenario_generation.proceed_to_next_day()
+        
+        # 게임 상태 업데이트
+        self.game_states[gameNo] = scenario_generation.game_state
 
-        new_victim = random.choice(remaining_npcs)
-        for npc in game_state["npcs"]:
-            if npc["name"] == new_victim["name"]:
-                game_state['alive'][npc['name']] = False
-                break
-        game_state['murdered_npcs'].append({"name": new_victim['name'], "order": game_state['current_day'] + 1})
+        return murder_summary
 
-        # 새로운 범행 도구와 장소를 할당
-        murderer = game_state['murderer']
-        new_weapon = random.choice(murderer["preferredWeapons"])
-        new_location = random.choice(murderer["preferredLocations"])
-        if 'murder_weapons' not in game_state:
-            game_state['murder_weapons'] = [new_weapon]
-        else:
-            game_state['murder_weapons'].append(new_weapon)
-        if 'murder_locations' not in game_state:
-            game_state['murder_locations'] = [new_location]
-        else:
-            game_state['murder_locations'].append(new_location)
-
-        game_state['current_day'] += 1
-        new_scenario = self.scenario_generations[gameNo].create_progress_scenario()
-
-        return {
-            "new_victim": new_victim['name'],
-            "new_weapon": new_weapon,
-            "new_location": new_location,
-            "current_day": game_state['current_day'],
-            "scenario": new_scenario
-        }
+    def filter_game_suspects(self, gameNo, weapon, location):
+        if gameNo not in self.hint_investigations:
+            raise ValueError(f"Game ID {gameNo} not found in hint investigations.")
+        return self.hint_investigations[gameNo].filter_suspects(weapon, location)
+    
+    # 알리바이와 목격자 정보를 생성하는 메서드
+    def generate_alibis_and_witness(self, gameNo):
+        if gameNo not in self.scenario_generations:
+            raise ValueError(f"Game ID {gameNo} not found in scenario generations.")
+        
+        alibis_and_witness = self.scenario_generations[gameNo].generate_alibis_and_witness()
+        self.game_states[gameNo].update(alibis_and_witness)
+        
+        return alibis_and_witness

--- a/app/services/game_service.py
+++ b/app/services/game_service.py
@@ -47,6 +47,9 @@ class GameService:
             game_management.names
         )
 
+        first_blood = self.scenario_generations[game_data.gameNo].get_first_blood()
+        game_state['first_blood'] = first_blood
+
         return game_state
 
     # 게임 상태를 반환하는 메서드

--- a/app/services/game_service.py
+++ b/app/services/game_service.py
@@ -14,9 +14,9 @@ class GameService:
         self.game_states: dict[int, dict] = {}
 
     # 새로운 게임을 시작하고 초기화하는 메서드
-    def initialize_new_game(self, gameNo, language, npc_count):
+    def initialize_new_game(self, gameNo, language):
         game_management = GameManagement()
-        game_management.initialize_game(language, npc_count)
+        game_management.initialize_game(language, 9)
         game_state = game_management.game_state
         game_state['current_day'] = 1
         game_state['alive'] = {npc["name"]: True for npc in game_state["npcs"]}

--- a/app/services/scenario_generation.py
+++ b/app/services/scenario_generation.py
@@ -258,4 +258,18 @@ class ScenarioGeneration:
         # result["answer"]["scenario"] = new_scenario
         
         return result
-    
+
+
+    # 게임 생성 직후 첫번째 희생자를 반환하는 메서드
+    def get_first_blood(self):
+        lang = self.game_state["language"]
+        victim_name = get_name(self.game_state['murdered_npc']["name"], lang, self.names)
+        crime_scene = get_location_name(self.game_state["murder_location"], self.places, lang)
+        murder_weapon = get_weapon_name(self.game_state["murder_weapon"], self.weapons, lang)
+
+        result = {
+            "victim": victim_name,
+            "crimeScene": crime_scene,
+            "method": murder_weapon,
+        }
+        return result

--- a/resources/data/features.json
+++ b/resources/data/features.json
@@ -7,6 +7,7 @@
         {"id": "Wanderer", "feature": {"en": "Wanderer", "ko": "떠돌이", "detail": {"en": "Travels between villages", "ko": "여러 마을을 떠돌아 다니는 떠돌이임"}}},
         {"id": "OldStyle", "feature": {"en": "OldStyle", "ko": "고어체", "detail": {"en": "Uses old-fashioned speech", "ko": "옛날 양식의 말투를 사용하여 대화함"}}},
         {"id": "Storyteller", "feature": {"en": "Storyteller", "ko": "이야기꾼", "detail": {"en": "Entertains others with interesting stories and legends", "ko": "흥미로운 이야기와 전설을 전하며 사람들을 즐겁게 함"}}},
+        {"id": "Explorer", "feature": {"en": "Explorer", "ko": "탐험가", "detail": {"en": "Enjoys exploring new places and cultures", "ko": "새로운 장소와 문화를 탐험하는 것을 좋아함"}}},
         {"id": "Naturalist", "feature": {"en": "Naturalist", "ko": "자연주의자", "detail": {"en": "Has deep knowledge and affection for nature and wildlife", "ko": "자연과 야생 동물에 대한 깊은 지식과 애정을 가짐"}}},
         {"id": "Humorous speech", "feature": {"en": "Humorous speech", "ko": "유머러스한 말투", "detail": {"en": "Often includes witty jokes in conversation", "ko": "대화 중에 종종 재치 있는 농담을 섞어 말함"}}},
         {"id": "Magician", "feature": {"en": "Magician", "ko": "마술사", "detail": {"en": "Surprises people with clever magic tricks and performances", "ko": "기발한 마술과 재치 있는 퍼포먼스로 사람들을 놀라게 함"}}},

--- a/resources/data/npcs.json
+++ b/resources/data/npcs.json
@@ -98,7 +98,7 @@
             "gender": "Female",
             "wealth": "High",
             "personality": "Skeptical",
-            "feature": "Scholar",
+            "feature": "Quiet",
             "preferredLocations": ["Library", "Office", "House"],
             "criminalScenario": "AcademicCuriosity"
         },


### PR DESCRIPTION
## 🌟(#이슈번호) 제목


## ✍️내용
- 게임 생성 시 npc 숫자 받는 부분 삭제 -> 고정으로 9명 들어가도록 수정
- 시작 시 9명이지만 한명은 죽고 시작하므로 NPC 는 8명
- 게임 생성 시 서버 (나영이) 로부터 주민과 범인 역의 NPC 이름 정보를 request 로 설정
- 그로 인한 GameStartRequest 스키마 설정
- 게임 상태에 알리바이 와 목격자 정보 추가 (사용할지는 모르겠음)
- 알리바이 와 목격자 정보 생성하는 API 라우터 추가
- 다음 날 넘어가는 API 에서 반환되는 response 구조 서버에 맞추어 변경
- 3개 질문 생성 및 대답 통신 시 스네이크 케이스 대신 카멜 케이스 로 변경
- NPC 정보 중 feature 에 마일로 의 탐험가 특징이 빠져있어 추가
- npc 중 자스민의 특징을 조용함으로 변경
- 게임 시작 시 첫번째 희생자 함께 반환하도록 추가

## 📸스크린샷


## 🎈참고사항